### PR TITLE
Revert "Bump activesupport from 6.1.4.4 to 6.1.7.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.1)
+    activesupport (6.1.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -18,9 +18,9 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)
-    i18n (1.12.0)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.17.0)
+    minitest (5.15.0)
     rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -35,9 +35,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)
-    tzinfo (2.0.5)
+    tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.6)
+    zeitwerk (2.5.3)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Reverts Negotiatus/Partial-Finder#2 - I merged this in before bumping the gem version